### PR TITLE
Modernize Orlando trip summary layout

### DIFF
--- a/orlando.html
+++ b/orlando.html
@@ -1,665 +1,389 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="pt-BR">
 <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Resumo da Viagem – Orlando 2026</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <style>
-        :root {
-            --accent: #0B5ED7;
-            --text: #212529;
-            --muted: #6C757D;
-            --border: #E9ECEF;
-            --bg-panel: #F7FAFF;
-            --bg-page: #FFFFFF;
-        }
-
-        * {
-            box-sizing: border-box;
-        }
-
-        body {
-            margin: 0;
-            padding: 32px;
-            font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-            font-size: 14px;
-            line-height: 1.6;
-            color: var(--text);
-            background: #F3F5F9;
-        }
-
-        .page {
-            max-width: 900px;
-            margin: 0 auto;
-            background: var(--bg-page);
-            padding: 32px 40px;
-            border-radius: 12px;
-            box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
-        }
-
-        h1, h2, h3, h4 {
-            margin: 0 0 8px;
-            font-weight: 600;
-        }
-
-            h1.title {
-                font-size: 26px;
-                color: var(--accent);
-                letter-spacing: 0.02em;
-                margin-bottom: 4px;
-            }
-
-        .subtitle-main {
-            font-size: 13px;
-            color: var(--muted);
-            margin-bottom: 4px;
-        }
-
-        .subtitle-meta {
-            font-size: 13px;
-            color: var(--muted);
-            margin-bottom: 18px;
-        }
-
-        hr.divider {
-            border: none;
-            border-top: 1px solid var(--border);
-            margin: 16px 0 18px;
-        }
-
-        .badge {
-            display: inline-flex;
-            align-items: center;
-            gap: 6px;
-            padding: 4px 10px;
-            border-radius: 999px;
-            font-size: 11px;
-            color: var(--accent);
-            background: #E7F0FF;
-            margin-bottom: 10px;
-            font-weight: 500;
-        }
-
-        .badge-dot {
-            width: 7px;
-            height: 7px;
-            border-radius: 50%;
-            background: var(--accent);
-        }
-
-        .section {
-            margin-bottom: 26px;
-        }
-
-        .section-title {
-            font-size: 18px;
-            color: var(--accent);
-            border-bottom: 1px solid var(--border);
-            padding-bottom: 4px;
-            margin-bottom: 10px;
-        }
-
-        .section-subtitle {
-            font-size: 15px;
-            color: var(--text);
-            margin-top: 14px;
-            margin-bottom: 6px;
-        }
-
-        .section-subsubtitle {
-            font-size: 14px;
-            color: var(--text);
-            margin-top: 10px;
-            margin-bottom: 4px;
-            font-weight: 600;
-        }
-
-        p {
-            margin: 0 0 6px;
-        }
-
-        .muted {
-            color: var(--muted);
-            font-size: 12px;
-        }
-
-        ul {
-            padding-left: 18px;
-            margin: 4px 0 8px;
-        }
-
-        li {
-            margin-bottom: 2px;
-        }
-
-        .panel {
-            border-radius: 10px;
-            border: 1px solid var(--border);
-            background: var(--bg-panel);
-            padding: 10px 12px;
-            margin: 6px 0 10px;
-        }
-
-        .panel-header {
-            font-size: 12px;
-            font-weight: 600;
-            color: var(--accent);
-            text-transform: uppercase;
-            letter-spacing: 0.06em;
-            margin-bottom: 4px;
-        }
-
-        .grid-2 {
-            display: grid;
-            grid-template-columns: 1.1fr 1.3fr;
-            gap: 8px 18px;
-            margin-top: 4px;
-        }
-
-        .label {
-            font-size: 12px;
-            font-weight: 500;
-            color: var(--muted);
-        }
-
-        .value {
-            font-size: 13px;
-        }
-
-        .chip-row {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 8px;
-            margin: 4px 0 6px;
-        }
-
-        .chip {
-            display: inline-flex;
-            align-items: center;
-            padding: 2px 8px;
-            border-radius: 999px;
-            font-size: 11px;
-            border: 1px solid var(--border);
-            color: var(--muted);
-            background: #FFFFFF;
-        }
-
-            .chip strong {
-                color: var(--accent);
-                margin-right: 4px;
-            }
-
-        .timeline {
-            border-left: 2px solid var(--border);
-            padding-left: 14px;
-            margin: 4px 0 6px;
-        }
-
-        .timeline-item {
-            margin-bottom: 6px;
-            position: relative;
-        }
-
-            .timeline-item::before {
-                content: "";
-                width: 8px;
-                height: 8px;
-                border-radius: 50%;
-                background: #FFFFFF;
-                border: 2px solid var(--accent);
-                position: absolute;
-                left: -19px;
-                top: 3px;
-            }
-
-        .timeline-time {
-            font-weight: 500;
-            font-size: 12px;
-            color: var(--accent);
-            margin-right: 6px;
-        }
-
-        .timeline-text {
-            font-size: 13px;
-        }
-
-        .table-like {
-            border-radius: 10px;
-            border: 1px solid var(--border);
-            overflow: hidden;
-            margin: 4px 0 10px;
-        }
-
-        .table-row {
-            display: grid;
-            grid-template-columns: 1.5fr 1fr 1.5fr;
-            border-top: 1px solid var(--border);
-            padding: 4px 10px;
-            font-size: 13px;
-            align-items: flex-start;
-        }
-
-            .table-row.header {
-                background: #F5F7FB;
-                font-weight: 600;
-                color: var(--accent);
-                border-top: none;
-            }
-
-            .table-row strong {
-                font-weight: 600;
-            }
-
-        .pill {
-            display: inline-flex;
-            padding: 1px 7px;
-            border-radius: 999px;
-            font-size: 11px;
-            border: 1px solid var(--border);
-            color: var(--muted);
-        }
-
-        @media print {
-            body {
-                background: #FFFFFF;
-                padding: 0;
-            }
-
-            .page {
-                box-shadow: none;
-                border-radius: 0;
-                max-width: none;
-                margin: 0;
-            }
-        }
-    </style>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"
+        integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <div class="page">
-        <!-- Header -->
-        <h1 class="title">Resumo da Viagem – Orlando 2026</h1>
-        <p class="subtitle-main">
-            <strong>Família 1:</strong> Bruno, Fernanda, Noah e Alice &nbsp;•&nbsp;
-            <strong>Família 2:</strong> Wilton e Célia
-        </p>
-        <p class="subtitle-meta">
-            <strong>Período:</strong> 22/02/2026 → 11/03/2026 &nbsp;•&nbsp;
-            <strong>Base:</strong> Davenport / Orlando – FL, EUA
-        </p>
-        <hr class="divider" />
-
-        <!-- 1. Detalhes dos voos -->
-        <div class="section">
-            <div class="badge">
-                <span class="badge-dot"></span>
-                Seção 1 — Voos
-            </div>
-            <h2 class="section-title">1. Detalhes dos voos – ambas as famílias</h2>
-
-            <h3 class="section-subtitle">1.1 Família 1 – Air Canada (PNR ADI6WR)</h3>
-            <p><strong>Passageiros:</strong> Bruno Pinto Brum; Fernanda Lee Guerra Marques Brum; Noah Marques Brum; Alice Brum (bebê no colo).</p>
-            <p><strong>Tarifa:</strong> Economy Basic (classe G).</p>
-            <p><strong>Bagagem:</strong> 1 item pessoal por passageiro (43 × 33 × 16 cm); sem bagagem de mão incluída; 1ª e 2ª malas despachadas incluídas (até 23 kg cada).</p>
-
-            <div class="panel">
-                <div class="panel-header">Ida – Domingo, 22/02/2026</div>
-                <p><strong>Voo:</strong> AC1638 — Montréal (YUL) → Orlando (MCO)</p>
-                <p><strong>Horário:</strong> 19:25 → 23:02</p>
-                <div class="chip-row">
-                    <span class="chip"><strong>Terminal:</strong> MCO – B</span>
-                    <span class="chip"><strong>Aeronave:</strong> Airbus A321-200</span>
-                    <span class="chip"><strong>Serviço de bordo:</strong> Air Canada Bistro (pago à parte)</span>
+    <div class="page-shell container-lg py-4 py-lg-5">
+        <header class="glass-card p-4 p-lg-5 mb-4">
+            <div class="d-flex flex-wrap align-items-center gap-3 mb-3">
+                <span class="badge-pill">
+                    <span class="dot"></span>
+                    Viagem • Orlando 2026
+                </span>
+                <div class="d-flex flex-wrap gap-2 ms-auto">
+                    <span class="meta-chip"><strong>Família 1:</strong> Bruno, Fernanda, Noah e Alice</span>
+                    <span class="meta-chip"><strong>Família 2:</strong> Wilton e Célia</span>
                 </div>
             </div>
+            <div class="d-flex flex-wrap gap-3 align-items-center mb-2">
+                <h1 class="fw-bold mb-0 text-primary">Resumo da Viagem – Orlando 2026</h1>
+                <span class="meta-chip text-primary"><strong>Período:</strong> 22/02 → 11/03/2026</span>
+            </div>
+            <p class="meta-bar mb-0">Base: Davenport / Orlando – FL, EUA</p>
+        </header>
 
-            <div class="panel">
-                <div class="panel-header">Volta – Quarta, 11/03/2026</div>
-                <p><strong>Voo:</strong> AC1641 — Orlando (MCO) → Montréal (YUL)</p>
-                <p><strong>Horário:</strong> 18:15 → 21:26</p>
-                <div class="chip-row">
-                    <span class="chip"><strong>Terminal:</strong> MCO – B</span>
-                    <span class="chip"><strong>Aeronave:</strong> Airbus A321-200</span>
+        <main class="d-flex flex-column gap-4">
+            <!-- 1. Detalhes dos voos -->
+            <section class="section-card p-4 p-lg-5">
+                <div class="section-heading">
+                    <span class="badge-pill"><span class="dot"></span> Seção 1 — Voos</span>
+                    <h2 class="h4 mb-0">1. Detalhes dos voos – ambas as famílias</h2>
                 </div>
-            </div>
 
-            <p class="muted">
-                Regras de embarque (voos Canadá ↔ EUA): check-in e despacho de bagagem até 60 min antes da partida;
-                deadline no portão 30 min antes; portão fecha 15 min antes do voo.
-            </p>
+                <article class="mb-4">
+                    <div class="d-flex flex-column flex-md-row align-items-md-center gap-3 mb-2">
+                        <h3 class="h5 mb-0">1.1 Família 1 – Air Canada (PNR ADI6WR)</h3>
+                        <span class="meta-chip"><strong>Tarifa:</strong> Economy Basic (classe G)</span>
+                        <span class="meta-chip"><strong>Bagagem:</strong> 1 item pessoal + 2 despachadas (23 kg)</span>
+                    </div>
+                    <p><strong>Passageiros:</strong> Bruno Pinto Brum; Fernanda Lee Guerra Marques Brum; Noah Marques Brum; Alice Brum (bebê no colo).</p>
 
-            <h3 class="section-subtitle">1.2 Família 2 – GOL Linhas Aéreas (PNR IEGFNU)</h3>
-            <p><strong>Passageiros:</strong> Célia de Fátima Guerra M de Almeida; Wilton Arcanjo Guimarães.</p>
-            <p><strong>Tarifa:</strong> LIGHT NEW – Cabine Econômica (classe O).</p>
-            <p><strong>Bagagem:</strong> 0 despachada incluída; bagagem de mão 2 volumes (10 kg + 12 kg, até 115 cm lineares); 1ª mala despachada opcional R$ 350 por trecho.</p>
+                    <div class="row g-3">
+                        <div class="col-12 col-lg-6">
+                            <div class="info-tile h-100">
+                                <p class="label">Ida – Domingo, 22/02/2026</p>
+                                <p class="mb-1"><strong>Voo:</strong> AC1638 — Montréal (YUL) → Orlando (MCO)</p>
+                                <p class="mb-2"><strong>Horário:</strong> 19:25 → 23:02</p>
+                                <div class="chip-row">
+                                    <span class="chip"><strong>Terminal:</strong> MCO – B</span>
+                                    <span class="chip"><strong>Aeronave:</strong> Airbus A321-200</span>
+                                    <span class="chip"><strong>Serviço:</strong> Air Canada Bistro (pago)</span>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-12 col-lg-6">
+                            <div class="info-tile h-100">
+                                <p class="label">Volta – Quarta, 11/03/2026</p>
+                                <p class="mb-1"><strong>Voo:</strong> AC1641 — Orlando (MCO) → Montréal (YUL)</p>
+                                <p class="mb-2"><strong>Horário:</strong> 18:15 → 21:26</p>
+                                <div class="chip-row">
+                                    <span class="chip"><strong>Terminal:</strong> MCO – B</span>
+                                    <span class="chip"><strong>Aeronave:</strong> Airbus A321-200</span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
 
-            <h4 class="section-subsubtitle">Célia – Ida (22/02/2026)</h4>
-            <ul>
-                <li>G3 1755 — GIG (T2) 06:00 → BSB 07:45 (Boeing 737-800)</li>
-                <li>Conexão em Brasília ~2h</li>
-                <li>G3 7602 — BSB 09:45 → MCO (Terminal C) 15:55 (Boeing 737 MAX)</li>
-            </ul>
+                    <p class="subdued mt-3 mb-0">
+                        Regras de embarque (voos Canadá ↔ EUA): check-in e despacho de bagagem até 60 min antes da partida; deadline no portão 30 min antes; portão fecha 15 min antes do voo.
+                    </p>
+                </article>
 
-            <h4 class="section-subsubtitle">Célia – Volta (11/03 → 12/03/2026)</h4>
-            <ul>
-                <li>G3 7601 — MCO (Terminal C) 22:00 → BSB 07:05 (+1) (Boeing 737 MAX)</li>
-                <li>Conexão em Brasília ~1h35</li>
-                <li>G3 2074 — BSB 08:40 → GIG (T2) 10:30 (Boeing 737-800)</li>
-            </ul>
+                <article>
+                    <div class="d-flex flex-column flex-md-row align-items-md-center gap-3 mb-2">
+                        <h3 class="h5 mb-0">1.2 Família 2 – GOL Linhas Aéreas (PNR IEGFNU)</h3>
+                        <span class="meta-chip"><strong>Tarifa:</strong> LIGHT NEW – Econômica (classe O)</span>
+                        <span class="meta-chip"><strong>Bagagem:</strong> 2 volumes de mão (10 kg + 12 kg)</span>
+                    </div>
+                    <p><strong>Passageiros:</strong> Célia de Fátima Guerra M de Almeida; Wilton Arcanjo Guimarães.</p>
 
-            <p><strong>Pagamento total Célia:</strong> Tarifa USD 380 (equivalente BRL 2.043,29) + taxas brasileiras (BR3, BR4, US2, YC, XY2, XA, AY, XF) + bagagem adquirida (BRL 700,00) = <strong>R$ 3.279,95</strong>.</p>
+                    <div class="row g-3">
+                        <div class="col-12 col-lg-6">
+                            <div class="info-tile h-100">
+                                <p class="label">Célia – Ida (22/02/2026)</p>
+                                <ul class="mb-2 ps-3">
+                                    <li>G3 1755 — GIG (T2) 06:00 → BSB 07:45 (Boeing 737-800)</li>
+                                    <li>Conexão em Brasília ~2h</li>
+                                    <li>G3 7602 — BSB 09:45 → MCO (Terminal C) 15:55 (Boeing 737 MAX)</li>
+                                </ul>
+                            </div>
+                        </div>
+                        <div class="col-12 col-lg-6">
+                            <div class="info-tile h-100">
+                                <p class="label">Célia – Volta (11/03 → 12/03/2026)</p>
+                                <ul class="mb-2 ps-3">
+                                    <li>G3 7601 — MCO (Terminal C) 22:00 → BSB 07:05 (+1) (Boeing 737 MAX)</li>
+                                    <li>Conexão em Brasília ~1h35</li>
+                                    <li>G3 2074 — BSB 08:40 → GIG (T2) 10:30 (Boeing 737-800)</li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
 
-            <h4 class="section-subsubtitle">Wilton – Itinerário</h4>
-            <p>Mesmo itinerário de voos da Célia (ida e volta).</p>
-            <p><strong>Pagamento total Wilton:</strong> Tarifa USD 380 (equivalente BRL 2.043,29) + taxas brasileiras = <strong>R$ 2.579,95</strong>.</p>
-        </div>
+                    <div class="info-grid mt-2">
+                        <div class="info-tile">
+                            <p class="label">Pagamento total Célia</p>
+                            <p class="value">R$ 3.279,95</p>
+                            <p class="subdued mb-0">Tarifa USD 380 (BRL 2.043,29) + taxas (BR3, BR4, US2, YC, XY2, XA, AY, XF) + bagagem (BRL 700,00).</p>
+                        </div>
+                        <div class="info-tile">
+                            <p class="label">Pagamento total Wilton</p>
+                            <p class="value">R$ 2.579,95</p>
+                            <p class="subdued mb-0">Tarifa USD 380 (BRL 2.043,29) + taxas brasileiras.</p>
+                        </div>
+                    </div>
+                </article>
+            </section>
 
-        <!-- 2. Airbnb -->
-        <div class="section">
-            <div class="badge">
-                <span class="badge-dot"></span>
-                Seção 2 — Hospedagem
-            </div>
-            <h2 class="section-title">2. Airbnb – hospedagem (código HMF5WZ5APC)</h2>
+            <!-- 2. Airbnb -->
+            <section class="section-card p-4 p-lg-5">
+                <div class="section-heading">
+                    <span class="badge-pill"><span class="dot"></span> Seção 2 — Hospedagem</span>
+                    <h2 class="h4 mb-0">2. Airbnb – hospedagem (código HMF5WZ5APC)</h2>
+                </div>
 
-            <p><strong>Imóvel:</strong> New &amp; Comfort Home • 3 Bed • 2.5 Bath • Near Disney</p>
+                <p class="lead mb-3"><strong>Imóvel:</strong> New &amp; Comfort Home • 3 Bed • 2.5 Bath • Near Disney</p>
 
-            <div class="panel">
-                <div class="panel-header">Dados principais</div>
-                <div class="grid-2">
-                    <div>
+                <div class="info-grid mb-3">
+                    <div class="info-tile">
                         <p class="label">Endereço</p>
                         <p class="value">677 Longboat Drive, Davenport, FL 33896, Estados Unidos</p>
                     </div>
-                    <div>
+                    <div class="info-tile">
                         <p class="label">Período</p>
-                        <p class="value">
-                            Check-in: 22/02/2026 a partir de 16:00<br />
-                            Check-out: 11/03/2026 até 10:00
-                        </p>
+                        <p class="mb-0"><strong>Check-in:</strong> 22/02/2026 a partir de 16:00</p>
+                        <p class="mb-0"><strong>Check-out:</strong> 11/03/2026 até 10:00</p>
                     </div>
-                    <div>
+                    <div class="info-tile">
                         <p class="label">Anfitriã</p>
-                        <p class="value">
-                            Fernanda Batista<br />
-                            Contato: +55 11 96578-0094 (telefone / WhatsApp)<br />
-                            Coanfitriões: Amy, Emma
-                        </p>
+                        <p class="mb-0">Fernanda Batista</p>
+                        <p class="mb-0">Contato: +55 11 96578-0094 (telefone / WhatsApp)</p>
+                        <p class="mb-0">Coanfitriões: Amy, Emma</p>
                     </div>
-                    <div>
+                    <div class="info-tile">
                         <p class="label">Regras principais</p>
-                        <p class="value">
-                            Máximo 8 hóspedes; animais de estimação permitidos; self check-in por fechadura inteligente.
-                        </p>
+                        <p class="mb-0">Máximo 8 hóspedes; animais de estimação permitidos; self check-in por fechadura inteligente.</p>
                     </div>
                 </div>
-            </div>
 
-            <p class="muted">
-                Wi-Fi e instruções finais de acesso serão enviados pelo Airbnb até 48h antes do check-in.
-            </p>
+                <p class="subdued">Wi-Fi e instruções finais de acesso serão enviados pelo Airbnb até 48h antes do check-in.</p>
 
-            <h3 class="section-subtitle">2.1 Financeiro da hospedagem (CAD)</h3>
-            <div class="table-like">
-                <div class="table-row header">
-                    <div>Item</div>
-                    <div>Valor (CAD)</div>
-                    <div>Detalhes</div>
+                <div class="divider-soft"></div>
+
+                <h3 class="h5 mb-3">2.1 Financeiro da hospedagem (CAD)</h3>
+                <div class="table-responsive">
+                    <table class="table table-hover align-middle table-modern mb-0">
+                        <thead>
+                            <tr>
+                                <th>Item</th>
+                                <th>Valor (CAD)</th>
+                                <th>Detalhes</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>Total da reserva</td>
+                                <td>3.786,43</td>
+                                <td>Valor completo da hospedagem (Airbnb).</td>
+                            </tr>
+                            <tr>
+                                <td>Parcela 1 (paga)</td>
+                                <td>1.941,90</td>
+                                <td>Pagamento em 22/10/2025.</td>
+                            </tr>
+                            <tr>
+                                <td>Saldo pendente</td>
+                                <td>1.844,53</td>
+                                <td>Vencimento em 07/02/2026.</td>
+                            </tr>
+                        </tbody>
+                    </table>
                 </div>
-                <div class="table-row">
-                    <div>Total da reserva</div>
-                    <div>3.786,43</div>
-                    <div>Valor completo da hospedagem (Airbnb).</div>
-                </div>
-                <div class="table-row">
-                    <div>Parcela 1 (paga)</div>
-                    <div>1.941,90</div>
-                    <div>Pagamento em 22/10/2025.</div>
-                </div>
-                <div class="table-row">
-                    <div>Saldo pendente</div>
-                    <div>1.844,53</div>
-                    <div>Vencimento em 07/02/2026.</div>
-                </div>
-            </div>
-        </div>
+            </section>
 
-        <!-- 3. Turo -->
-        <div class="section">
-            <div class="badge">
-                <span class="badge-dot"></span>
-                Seção 3 — Carro (Turo)
-            </div>
-            <h2 class="section-title">3. Turo – detalhes da reserva do carro</h2>
+            <!-- 3. Turo -->
+            <section class="section-card p-4 p-lg-5">
+                <div class="section-heading">
+                    <span class="badge-pill"><span class="dot"></span> Seção 3 — Carro (Turo)</span>
+                    <h2 class="h4 mb-0">3. Turo – detalhes da reserva do carro</h2>
+                </div>
 
-            <p><strong>Veículo:</strong> Dodge Grand Caravan 2019 (host Leonardo E) – Placa BL76KP</p>
-            <p><strong>Local:</strong> Orlando International Airport (MCO)</p>
+                <p class="mb-1"><strong>Veículo:</strong> Dodge Grand Caravan 2019 (host Leonardo E) – Placa BL76KP</p>
+                <p class="mb-3"><strong>Local:</strong> Orlando International Airport (MCO)</p>
 
-            <div class="panel">
-                <div class="panel-header">Datas da reserva</div>
-                <div class="grid-2">
-                    <div>
+                <div class="info-grid mb-3">
+                    <div class="info-tile">
                         <p class="label">Retirada</p>
                         <p class="value">23/02/2026 às 00:30 – MCO (lockbox)</p>
                     </div>
-                    <div>
+                    <div class="info-tile">
                         <p class="label">Devolução</p>
                         <p class="value">11/03/2026 às 15:00 – MCO</p>
                     </div>
                 </div>
-            </div>
 
-            <h3 class="section-subtitle">3.1 Extras contratados</h3>
-            <ul>
-                <li>2 cadeirinhas infantis — US$ 39 cada (US$ 78 no total)</li>
-                <li>1 carrinho de bebê — US$ 55</li>
-                <li>Enhanced roadside assistance — US$ 50,83</li>
-                <li>Standard protection plan — incluído</li>
-            </ul>
-
-            <h3 class="section-subtitle">3.2 Custos totais (USD)</h3>
-            <ul>
-                <li>Trip price: US$ 623,05</li>
-                <li>Child seats: US$ 78,00</li>
-                <li>Stroller: US$ 55,00</li>
-                <li>Trip fee: US$ 15,00</li>
-                <li>Airport permit fee: US$ 86,59</li>
-                <li>Sales tax: US$ 46,28</li>
-                <li>Standard protection: US$ 205,24</li>
-                <li>Descontos: −US$ 51,31 (protection plan) e −US$ 109,95 (2-week discount)</li>
-            </ul>
-            <p><strong>Total Turo (USD):</strong> US$ 998,73</p>
-
-            <h3 class="section-subtitle">3.3 Cobrança real no cartão (CAD)</h3>
-            <div class="table-like">
-                <div class="table-row header">
-                    <div>Data</div>
-                    <div>Valor (CAD)</div>
-                    <div>Descrição</div>
-                </div>
-                <div class="table-row">
-                    <div>23/10/2025</div>
-                    <div>1.181,97</div>
-                    <div>Primeira cobrança da reserva Turo.</div>
-                </div>
-                <div class="table-row">
-                    <div>25/10/2025</div>
-                    <div>217,57</div>
-                    <div>Complemento da reserva.</div>
-                </div>
-                <div class="table-row">
-                    <div><strong>Total no cartão</strong></div>
-                    <div><strong>1.399,54</strong></div>
-                    <div><strong>Somatório das duas transações em CAD.</strong></div>
-                </div>
-            </div>
-
-            <p><strong>Quilometragem:</strong> 5.950 milhas incluídas • limite 350 mi/dia • excedente: US$ 0,09 por milha.</p>
-            <p class="muted">
-                Política: reserva non-refundable, com possibilidade de cancelamento total em até 24h após reserva (regra específica do anúncio).
-            </p>
-        </div>
-
-        <!-- 4. Financeiro -->
-        <div class="section">
-            <div class="badge">
-                <span class="badge-dot"></span>
-                Seção 4 — Financeiro
-            </div>
-            <h2 class="section-title">4. Financeiro da viagem</h2>
-
-            <h3 class="section-subtitle">4.1 Entradas (por moeda)</h3>
-            <div class="panel">
-                <div class="panel-header">Valores em CAD</div>
-                <ul>
-                    <li><strong>Hospedagem_total_cad:</strong> 3.786,43</li>
-                    <li><strong>Turo_total_cad:</strong> 1.399,54</li>
-                    <li><strong>Extras_compartilhados_cad:</strong> 0,00</li>
-                    <li><strong>Voos_família_1_cad:</strong> 935,60</li>
+                <h3 class="h6 text-uppercase text-muted mt-2">3.1 Extras contratados</h3>
+                <ul class="mb-3 ps-3">
+                    <li>2 cadeirinhas infantis — US$ 39 cada (US$ 78 no total)</li>
+                    <li>1 carrinho de bebê — US$ 55</li>
+                    <li>Enhanced roadside assistance — US$ 50,83</li>
+                    <li>Standard protection plan — incluído</li>
                 </ul>
-            </div>
-            <div class="panel">
-                <div class="panel-header">Valores em BRL</div>
-                <ul>
-                    <li><strong>Voos_família_2 (BRL):</strong> R$ 5.859,90 = R$ 3.279,95 (Célia) + R$ 2.579,95 (Wilton)</li>
+
+                <h3 class="h6 text-uppercase text-muted">3.2 Custos totais (USD)</h3>
+                <ul class="mb-3 ps-3">
+                    <li>Trip price: US$ 623,05</li>
+                    <li>Child seats: US$ 78,00</li>
+                    <li>Stroller: US$ 55,00</li>
+                    <li>Trip fee: US$ 15,00</li>
+                    <li>Airport permit fee: US$ 86,59</li>
+                    <li>Sales tax: US$ 46,28</li>
+                    <li>Standard protection: US$ 205,24</li>
+                    <li>Descontos: −US$ 51,31 (protection plan) e −US$ 109,95 (2-week discount)</li>
                 </ul>
-            </div>
+                <p class="fw-semibold">Total Turo (USD): US$ 998,73</p>
 
-            <h3 class="section-subtitle">4.2 Cálculos dos custos compartilhados (CAD)</h3>
-            <p><strong>Passo 1 – Total compartilhado:</strong></p>
-            <p>
-                Compartilhado_total = hospedagem_total_cad + turo_total_cad + extras_compartilhados_cad<br />
-                = 3.786,43 + 1.399,54 + 0,00 = <strong>5.185,97 CAD</strong>
-            </p>
+                <h3 class="h6 text-uppercase text-muted">3.3 Cobrança real no cartão (CAD)</h3>
+                <div class="table-responsive mb-3">
+                    <table class="table table-hover align-middle table-modern mb-0">
+                        <thead>
+                            <tr>
+                                <th>Data</th>
+                                <th>Valor (CAD)</th>
+                                <th>Descrição</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>23/10/2025</td>
+                                <td>1.181,97</td>
+                                <td>Primeira cobrança da reserva Turo.</td>
+                            </tr>
+                            <tr>
+                                <td>25/10/2025</td>
+                                <td>217,57</td>
+                                <td>Complemento da reserva.</td>
+                            </tr>
+                            <tr class="fw-semibold">
+                                <td>Total no cartão</td>
+                                <td>1.399,54</td>
+                                <td>Somatório das duas transações em CAD.</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
 
-            <p><strong>Passo 2 – Cota por família:</strong></p>
-            <p>
-                Cota_por_família = 5.185,97 ÷ 2 = <strong>2.592,99 CAD</strong>
-            </p>
+                <p class="mb-0"><strong>Quilometragem:</strong> 5.950 milhas incluídas • limite 350 mi/dia • excedente: US$ 0,09 por milha.</p>
+                <p class="subdued mb-0">Política: reserva non-refundable, com possibilidade de cancelamento total em até 24h após reserva (regra específica do anúncio).</p>
+            </section>
 
-            <h3 class="section-subtitle">4.3 Totais por família</h3>
+            <!-- 4. Financeiro -->
+            <section class="section-card p-4 p-lg-5">
+                <div class="section-heading">
+                    <span class="badge-pill"><span class="dot"></span> Seção 4 — Financeiro</span>
+                    <h2 class="h4 mb-0">4. Financeiro da viagem</h2>
+                </div>
 
-            <div class="panel">
-                <div class="panel-header">Família 1 – Bruno, Fernanda, Noah e Alice</div>
-                <p>
-                    <strong>Total_Família_1 = 2.592,99 (hospedagem + carro) + 935,60 (avião) = 3.528,59 CAD</strong>
-                </p>
-                <p class="muted">
-                    Onde:<br />
-                    • 2.592,99 CAD = cota da família sobre o total compartilhado (Airbnb + Turo).<br />
-                    • 935,60 CAD = valor total das passagens Air Canada para a família 1.
-                </p>
-            </div>
+                <div class="row g-3 mb-3">
+                    <div class="col-12 col-lg-6">
+                        <div class="info-tile h-100">
+                            <p class="label">Valores em CAD</p>
+                            <ul class="mb-0 ps-3">
+                                <li><strong>Hospedagem_total_cad:</strong> 3.786,43</li>
+                                <li><strong>Turo_total_cad:</strong> 1.399,54</li>
+                                <li><strong>Extras_compartilhados_cad:</strong> 0,00</li>
+                                <li><strong>Voos_família_1_cad:</strong> 935,60</li>
+                            </ul>
+                        </div>
+                    </div>
+                    <div class="col-12 col-lg-6">
+                        <div class="info-tile h-100">
+                            <p class="label">Valores em BRL</p>
+                            <ul class="mb-0 ps-3">
+                                <li><strong>Voos_wilton_brl:</strong> 2.579,95</li>
+                                <li><strong>Voos_celia_brl:</strong> 3.279,95</li>
+                                <li><strong>Extras_compartilhados_brl:</strong> 0,00</li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
 
-            <div class="panel">
-                <div class="panel-header">Família 2 – Wilton e Célia</div>
-                <p>
-                    <strong>Total_Família_2 = 2.592,99 CAD (hospedagem + carro) + R$ 5.859,90 (voos em BRL)</strong>
-                </p>
-                <p class="muted">
-                    Os voos da família 2 foram pagos em reais (R$ 3.279,95 Célia + R$ 2.579,95 Wilton). A decisão foi manter esses
-                    valores em BRL, sem conversão para CAD, para preservar a fidelidade aos valores efetivamente cobrados.
-                </p>
-            </div>
-        </div>
+                <div class="info-grid">
+                    <div class="info-tile">
+                        <p class="label">Família 1 – Bruno, Fernanda, Noah e Alice</p>
+                        <p class="mb-0"><strong>Total_Família_1 = 2.592,99 (hospedagem + carro) + 935,60 (avião) = 3.528,59 CAD</strong></p>
+                        <p class="subdued mb-0">Onde: 2.592,99 CAD = cota da família sobre o total compartilhado (Airbnb + Turo). 935,60 CAD = valor total das passagens Air Canada para a família 1.</p>
+                    </div>
+                    <div class="info-tile">
+                        <p class="label">Família 2 – Wilton e Célia</p>
+                        <p class="mb-0"><strong>Total_Família_2 = 2.592,99 CAD (hospedagem + carro) + R$ 5.859,90 (voos em BRL)</strong></p>
+                        <p class="subdued mb-0">Os voos da família 2 foram pagos em reais para manter os valores conforme cobrança real.</p>
+                    </div>
+                </div>
+            </section>
 
-        <!-- 5. Linha do tempo -->
-        <div class="section">
-            <div class="badge">
-                <span class="badge-dot"></span>
-                Seção 5 — Linha do tempo
-            </div>
-            <h2 class="section-title">5. Linha do tempo da viagem</h2>
+            <!-- 5. Linha do tempo -->
+            <section class="section-card p-4 p-lg-5">
+                <div class="section-heading">
+                    <span class="badge-pill"><span class="dot"></span> Seção 5 — Linha do tempo</span>
+                    <h2 class="h4 mb-0">5. Linha do tempo da viagem</h2>
+                </div>
 
-            <h3 class="section-subtitle">22/02/2026 – Domingo</h3>
-            <div class="timeline">
-                <div class="timeline-item">
-                    <span class="timeline-time">15:55</span>
-                    <span class="timeline-text">Chegada de Célia &amp; Wilton ao MCO – Terminal C.</span>
+                <h3 class="h6 text-uppercase text-muted">22/02/2026 – Domingo</h3>
+                <div class="timeline mb-3">
+                    <div class="timeline-item"><span class="timeline-time">15:55</span>Chegada de Célia &amp; Wilton ao MCO – Terminal C.</div>
+                    <div class="timeline-item"><span class="timeline-time">16:00</span>Check-in liberado no Airbnb em Davenport.</div>
+                    <div class="timeline-item"><span class="timeline-time">19:25</span>Decolagem do voo AC1638 de Montréal (YUL) para Orlando (MCO).</div>
+                    <div class="timeline-item"><span class="timeline-time">23:02</span>Chegada de Bruno &amp; família ao MCO – Terminal B.</div>
                 </div>
-                <div class="timeline-item">
-                    <span class="timeline-time">16:00</span>
-                    <span class="timeline-text">Check-in liberado no Airbnb em Davenport.</span>
-                </div>
-                <div class="timeline-item">
-                    <span class="timeline-time">19:25</span>
-                    <span class="timeline-text">Decolagem do voo AC1638 de Montréal (YUL) para Orlando (MCO).</span>
-                </div>
-                <div class="timeline-item">
-                    <span class="timeline-time">23:02</span>
-                    <span class="timeline-text">Chegada de Bruno &amp; família ao MCO – Terminal B.</span>
-                </div>
-            </div>
 
-            <h3 class="section-subtitle">23/02/2026 – Segunda</h3>
-            <div class="timeline">
-                <div class="timeline-item">
-                    <span class="timeline-time">00:30</span>
-                    <span class="timeline-text">Retirada do carro (Turo) no aeroporto MCO (lockbox).</span>
+                <h3 class="h6 text-uppercase text-muted">23/02/2026 – Segunda</h3>
+                <div class="timeline mb-3">
+                    <div class="timeline-item"><span class="timeline-time">00:30</span>Retirada do carro (Turo) no aeroporto MCO (lockbox).</div>
                 </div>
-            </div>
 
-            <h3 class="section-subtitle">11/03/2026 – Quarta (retornos)</h3>
-            <div class="timeline">
-                <div class="timeline-item">
-                    <span class="timeline-time">10:00</span>
-                    <span class="timeline-text">Check-out do Airbnb em Davenport.</span>
+                <h3 class="h6 text-uppercase text-muted">11/03/2026 – Quarta (retornos)</h3>
+                <div class="timeline">
+                    <div class="timeline-item"><span class="timeline-time">10:00</span>Check-out do Airbnb em Davenport.</div>
+                    <div class="timeline-item"><span class="timeline-time">15:00</span>Devolução do carro no Turo – MCO.</div>
+                    <div class="timeline-item"><span class="timeline-time">18:15</span>Voo AC1641 decola de MCO para YUL (família 1).</div>
+                    <div class="timeline-item"><span class="timeline-time">22:00</span>Voo G3 7601 decola de MCO para BSB (família 2, com chegada no dia seguinte).</div>
                 </div>
-                <div class="timeline-item">
-                    <span class="timeline-time">15:00</span>
-                    <span class="timeline-text">Devolução do carro no Turo – MCO.</span>
-                </div>
-                <div class="timeline-item">
-                    <span class="timeline-time">18:15</span>
-                    <span class="timeline-text">Voo AC1641 decola de MCO para YUL (família 1).</span>
-                </div>
-                <div class="timeline-item">
-                    <span class="timeline-time">22:00</span>
-                    <span class="timeline-text">Voo G3 7601 decola de MCO para BSB (família 2, com chegada no dia seguinte).</span>
-                </div>
-            </div>
-        </div>
+            </section>
 
-        <!-- 6. Lembretes -->
-        <div class="section">
-            <div class="badge">
-                <span class="badge-dot"></span>
-                Seção 6 — Lembretes
-            </div>
-            <h2 class="section-title">6. Lembretes criados</h2>
+            <!-- 6. Lembretes -->
+            <section class="section-card p-4 p-lg-5">
+                <div class="section-heading">
+                    <span class="badge-pill"><span class="dot"></span> Seção 6 — Lembretes</span>
+                    <h2 class="h4 mb-0">6. Lembretes criados</h2>
+                </div>
 
-            <div class="table-like">
-                <div class="table-row header">
-                    <div>Quando</div>
-                    <div>Item</div>
-                    <div>Descrição</div>
+                <div class="table-responsive">
+                    <table class="table table-striped align-middle table-modern mb-0">
+                        <thead>
+                            <tr>
+                                <th>Quando</th>
+                                <th>Item</th>
+                                <th>Descrição</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>07/02/2026</td>
+                                <td>Pagamento Airbnb</td>
+                                <td>Quitar saldo da hospedagem no valor de CAD 1.844,53.</td>
+                            </tr>
+                            <tr>
+                                <td>20/02/2026</td>
+                                <td>Wi-Fi / Acesso</td>
+                                <td>Conferir credenciais do Wi-Fi e instruções finais de acesso enviadas pela anfitriã.</td>
+                            </tr>
+                            <tr>
+                                <td>22/02/2026</td>
+                                <td>Rota até o Airbnb</td>
+                                <td>Salvar rota até o endereço: 677 Longboat Drive, Davenport, FL 33896.</td>
+                            </tr>
+                            <tr>
+                                <td>Contato útil</td>
+                                <td>Anfitriã Airbnb</td>
+                                <td>Fernanda Batista – telefone/WhatsApp: +55 11 96578-0094 (associado aos lembretes).</td>
+                            </tr>
+                        </tbody>
+                    </table>
                 </div>
-                <div class="table-row">
-                    <div>07/02/2026</div>
-                    <div>Pagamento Airbnb</div>
-                    <div>Quitar saldo da hospedagem no valor de CAD 1.844,53.</div>
-                </div>
-                <div class="table-row">
-                    <div>20/02/2026</div>
-                    <div>Wi-Fi / Acesso</div>
-                    <div>Conferir credenciais do Wi-Fi e instruções finais de acesso enviadas pela anfitriã.</div>
-                </div>
-                <div class="table-row">
-                    <div>22/02/2026</div>
-                    <div>Rota até o Airbnb</div>
-                    <div>Salvar rota até o endereço: 677 Longboat Drive, Davenport, FL 33896.</div>
-                </div>
-                <div class="table-row">
-                    <div>Contato útil</div>
-                    <div>Anfitriã Airbnb</div>
-                    <div>Fernanda Batista – telefone/WhatsApp: +55 11 96578-0094 (associado aos lembretes).</div>
-                </div>
-            </div>
-        </div>
+            </section>
 
-        <p class="muted" style="margin-top: 16px;">
-            Documento consolidado a partir de: reservas Air Canada, GOL, Airbnb e Turo. Valores em CAD e BRL conforme
-            cobrança real informada.
-        </p>
+            <p class="footer-note mt-2 mb-0">Documento consolidado a partir de: reservas Air Canada, GOL, Airbnb e Turo. Valores em CAD e BRL conforme cobrança real informada.</p>
+        </main>
     </div>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,217 @@
+:root {
+    --accent: #2563eb;
+    --accent-soft: #e0e7ff;
+    --text: #0f172a;
+    --muted: #6b7280;
+    --border: #e2e8f0;
+    --surface: #ffffff;
+    --surface-alt: #f8fafc;
+    --shadow: 0 20px 55px rgba(15, 23, 42, 0.12);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background: radial-gradient(circle at 10% 20%, rgba(37, 99, 235, 0.12), transparent 25%),
+        radial-gradient(circle at 80% 0%, rgba(99, 102, 241, 0.12), transparent 30%),
+        #f1f5f9;
+    color: var(--text);
+    min-height: 100vh;
+}
+
+.page-shell {
+    max-width: 1100px;
+}
+
+.glass-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 16px;
+    box-shadow: var(--shadow);
+}
+
+.section-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+}
+
+.section-heading {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 12px;
+}
+
+.badge-pill {
+    background: var(--accent-soft);
+    color: var(--accent);
+    border-radius: 999px;
+    font-weight: 600;
+    padding: 8px 14px;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+    font-size: 12px;
+}
+
+.badge-pill .dot {
+    width: 10px;
+    height: 10px;
+    background: var(--accent);
+    border-radius: 50%;
+}
+
+.meta-bar {
+    color: var(--muted);
+}
+
+.meta-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    border-radius: 10px;
+    border: 1px solid var(--border);
+    background: var(--surface-alt);
+    font-size: 13px;
+    color: var(--muted);
+}
+
+.subdued {
+    color: var(--muted);
+    font-size: 14px;
+}
+
+.divider-soft {
+    height: 1px;
+    background: linear-gradient(90deg, transparent, var(--border), transparent);
+    margin: 20px 0;
+}
+
+.info-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 14px 18px;
+}
+
+.info-tile {
+    background: var(--surface-alt);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 12px 14px;
+}
+
+.info-tile .label {
+    font-size: 12px;
+    color: var(--muted);
+    letter-spacing: 0.01em;
+    margin-bottom: 4px;
+}
+
+.info-tile .value {
+    font-weight: 600;
+    color: var(--text);
+}
+
+.chip-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--muted);
+    font-size: 12px;
+}
+
+.chip strong {
+    color: var(--text);
+}
+
+.timeline {
+    position: relative;
+    padding-left: 18px;
+    margin-top: 8px;
+}
+
+.timeline::before {
+    content: "";
+    position: absolute;
+    left: 6px;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background: var(--border);
+}
+
+.timeline-item {
+    position: relative;
+    padding: 8px 12px 8px 24px;
+    margin-bottom: 6px;
+    border-radius: 10px;
+    background: var(--surface-alt);
+    border: 1px solid var(--border);
+}
+
+.timeline-item::before {
+    content: "";
+    position: absolute;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: var(--surface);
+    border: 2px solid var(--accent);
+    left: -10px;
+    top: 14px;
+}
+
+.timeline-time {
+    color: var(--accent);
+    font-weight: 700;
+    font-size: 13px;
+    margin-right: 8px;
+}
+
+.table-modern th {
+    color: var(--muted);
+    font-weight: 600;
+    text-transform: uppercase;
+    font-size: 12px;
+    letter-spacing: 0.04em;
+}
+
+.table-modern td strong {
+    color: var(--text);
+}
+
+.footer-note {
+    color: var(--muted);
+    font-size: 13px;
+    text-align: center;
+}
+
+@media (max-width: 576px) {
+    .glass-card,
+    .section-card {
+        border-radius: 12px;
+    }
+
+    .chip-row {
+        gap: 8px;
+    }
+}


### PR DESCRIPTION
## Summary
- rebuild the Orlando trip summary using a Bootstrap-based layout with modern cards and badges
- improve readability and responsiveness for flight, hospedagem, carro, financeiro, linha do tempo e lembretes sections
- extract theme and utility styles into a dedicated stylesheet for easier maintenance

## Testing
- Not run (static HTML)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a7cddd534832988f0a0909b140b6b)