### PR TITLE
Remove libs ausentes do template

### DIFF
--- a/public/assets/js/app.js
+++ b/public/assets/js/app.js
@@ -52,7 +52,9 @@ File: Main Js File
 
     function initMetisMenu() {
         //metis menu
-        $("#side-menu").metisMenu();
+        if ($.fn && $.fn.metisMenu) {
+            $("#side-menu").metisMenu();
+        }
     }
 
     function initLeftMenuCollapse() {
@@ -289,7 +291,9 @@ File: Main Js File
         initSettings();
         initLanguage();
         initPreloader();
-        Waves.init();
+        if (window.Waves && typeof Waves.init === "function") {
+            Waves.init();
+        }
         initCheckAll();
     }
     $(document).ready(function () {

--- a/public/confirm-mail.html
+++ b/public/confirm-mail.html
@@ -59,9 +59,6 @@
     </div>
     <script src="/assets/libs/jquery/jquery.min.js"></script>
     <script src="/assets/libs/bootstrap/js/bootstrap.bundle.min.js"></script>
-    <script src="/assets/libs/metismenu/metisMenu.min.js"></script>
-    <script src="/assets/libs/simplebar/simplebar.min.js"></script>
-    <script src="/assets/libs/node-waves/waves.min.js"></script>
     <script src="/assets/libs/owl.carousel/owl.carousel.min.js"></script>
     <script src="/assets/js/pages/auth-2-carousel.init.js"></script>
     <script src="/assets/js/sentry-init.js"></script>

--- a/public/email-verification.html
+++ b/public/email-verification.html
@@ -60,9 +60,6 @@
     </div>
     <script src="/assets/libs/jquery/jquery.min.js"></script>
     <script src="/assets/libs/bootstrap/js/bootstrap.bundle.min.js"></script>
-    <script src="/assets/libs/metismenu/metisMenu.min.js"></script>
-    <script src="/assets/libs/simplebar/simplebar.min.js"></script>
-    <script src="/assets/libs/node-waves/waves.min.js"></script>
     <script src="/assets/libs/owl.carousel/owl.carousel.min.js"></script>
     <script src="/assets/js/pages/auth-2-carousel.init.js"></script>
     <script src="/assets/js/sentry-init.js"></script>

--- a/public/forgot.html
+++ b/public/forgot.html
@@ -69,9 +69,6 @@
     </div>
     <script src="/assets/libs/jquery/jquery.min.js"></script>
     <script src="/assets/libs/bootstrap/js/bootstrap.bundle.min.js"></script>
-    <script src="/assets/libs/metismenu/metisMenu.min.js"></script>
-    <script src="/assets/libs/simplebar/simplebar.min.js"></script>
-    <script src="/assets/libs/node-waves/waves.min.js"></script>
     <script src="/assets/libs/owl.carousel/owl.carousel.min.js"></script>
     <script src="/assets/js/pages/auth-2-carousel.init.js"></script>
     <script src="/assets/js/pages/two-step-verification.init.js"></script>

--- a/public/group-details.html
+++ b/public/group-details.html
@@ -1543,9 +1543,6 @@
 
     <script src="/assets/libs/jquery/jquery.min.js"></script>
     <script src="/assets/libs/bootstrap/js/bootstrap.bundle.min.js"></script>
-    <script src="/assets/libs/metismenu/metisMenu.min.js"></script>
-    <script src="/assets/libs/simplebar/simplebar.min.js"></script>
-    <script src="/assets/libs/node-waves/waves.min.js"></script>
     <script src="/assets/js/sentry-init.js"></script>
     <script src="/assets/js/app.js"></script>
     <script src="group.js" defer></script>

--- a/public/group.html
+++ b/public/group.html
@@ -375,9 +375,6 @@
 
     <script src="/assets/libs/jquery/jquery.min.js"></script>
     <script src="/assets/libs/bootstrap/js/bootstrap.bundle.min.js"></script>
-    <script src="/assets/libs/metismenu/metisMenu.min.js"></script>
-    <script src="/assets/libs/simplebar/simplebar.min.js"></script>
-    <script src="/assets/libs/node-waves/waves.min.js"></script>
     <script src="/assets/js/sentry-init.js"></script>
     <script src="/assets/js/app.js"></script>
     <script src="group.js" defer></script>

--- a/public/groups.html
+++ b/public/groups.html
@@ -316,9 +316,6 @@
 
     <script src="/assets/libs/jquery/jquery.min.js"></script>
     <script src="/assets/libs/bootstrap/js/bootstrap.bundle.min.js"></script>
-    <script src="/assets/libs/metismenu/metisMenu.min.js"></script>
-    <script src="/assets/libs/simplebar/simplebar.min.js"></script>
-    <script src="/assets/libs/node-waves/waves.min.js"></script>
     <script src="/assets/js/sentry-init.js"></script>
     <script src="/assets/js/app.js"></script>
     <script src="groups.js" defer></script>

--- a/public/login.html
+++ b/public/login.html
@@ -119,9 +119,6 @@
     </div>
     <script src="/assets/libs/jquery/jquery.min.js"></script>
     <script src="/assets/libs/bootstrap/js/bootstrap.bundle.min.js"></script>
-    <script src="/assets/libs/metismenu/metisMenu.min.js"></script>
-    <script src="/assets/libs/simplebar/simplebar.min.js"></script>
-    <script src="/assets/libs/node-waves/waves.min.js"></script>
     <script src="/assets/libs/owl.carousel/owl.carousel.min.js"></script>
     <script src="/assets/js/pages/auth-2-carousel.init.js"></script>
     <script src="/assets/js/pages/two-step-verification.init.js"></script>

--- a/public/register.html
+++ b/public/register.html
@@ -157,9 +157,6 @@
     </div>
     <script src="/assets/libs/jquery/jquery.min.js"></script>
     <script src="/assets/libs/bootstrap/js/bootstrap.bundle.min.js"></script>
-    <script src="/assets/libs/metismenu/metisMenu.min.js"></script>
-    <script src="/assets/libs/simplebar/simplebar.min.js"></script>
-    <script src="/assets/libs/node-waves/waves.min.js"></script>
     <script src="/assets/libs/owl.carousel/owl.carousel.min.js"></script>
     <script src="/assets/js/pages/auth-2-carousel.init.js"></script>
     <script src="/assets/js/pages/two-step-verification.init.js"></script>

--- a/public/reset.html
+++ b/public/reset.html
@@ -69,9 +69,6 @@
     </div>
     <script src="/assets/libs/jquery/jquery.min.js"></script>
     <script src="/assets/libs/bootstrap/js/bootstrap.bundle.min.js"></script>
-    <script src="/assets/libs/metismenu/metisMenu.min.js"></script>
-    <script src="/assets/libs/simplebar/simplebar.min.js"></script>
-    <script src="/assets/libs/node-waves/waves.min.js"></script>
     <script src="/assets/libs/owl.carousel/owl.carousel.min.js"></script>
     <script src="/assets/js/pages/auth-2-carousel.init.js"></script>
     <script src="/assets/js/pages/two-step-verification.init.js"></script>

--- a/public/two-step-verification.html
+++ b/public/two-step-verification.html
@@ -102,9 +102,6 @@
     </div>
     <script src="/assets/libs/jquery/jquery.min.js"></script>
     <script src="/assets/libs/bootstrap/js/bootstrap.bundle.min.js"></script>
-    <script src="/assets/libs/metismenu/metisMenu.min.js"></script>
-    <script src="/assets/libs/simplebar/simplebar.min.js"></script>
-    <script src="/assets/libs/node-waves/waves.min.js"></script>
     <script src="/assets/libs/owl.carousel/owl.carousel.min.js"></script>
     <script src="/assets/js/pages/two-step-verification.init.js"></script>
     <script src="/assets/js/sentry-init.js"></script>


### PR DESCRIPTION
Remove includes de scripts que nao existem em public/assets/libs (metisMenu/simplebar/waves) e adiciona guards em public/assets/js/app.js para nao quebrar quando essas libs nao estao presentes.\n\nIsso elimina erros no console e evita ruido no GlitchTip.