### PR TITLE
fix: corrige integração GlitchTip

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,7 @@ GLITCHTIP_PUBLIC_ORIGIN=http://localhost:8000
 GLITCHTIP_ENVIRONMENT=development
 GLITCHTIP_RELEASE=
 GLITCHTIP_TRACES_SAMPLE_RATE=0.1
+# Variaveis para o script de setup de alerts (scripts/setup-glitchtip-github-issues-alerts.ps1)
+GLITCHTIP_API_TOKEN=
+GLITCHTIP_GITHUB_ISSUES_WEBHOOK_URL=https://your-worker.workers.dev/webhook/glitchtip
+GLITCHTIP_GITHUB_ISSUES_WEBHOOK_TOKEN=change-me

--- a/public/assets/js/sentry-init.js
+++ b/public/assets/js/sentry-init.js
@@ -1,6 +1,6 @@
 (() => {
     const configUrl = '/api/config/sentry';
-    const sentryCdnUrl = 'https://browser.sentry-cdn.com/7.60.0/bundle.min.js';
+    const sentryCdnUrl = 'https://browser.sentry-cdn.com/7.120.0/bundle.min.js';
 
     const loadScript = (src) => new Promise((resolve, reject) => {
         const script = document.createElement('script');

--- a/public/invite.html
+++ b/public/invite.html
@@ -122,6 +122,7 @@
 
     <script src="/assets/libs/jquery/jquery.min.js"></script>
     <script src="/assets/libs/bootstrap/js/bootstrap.bundle.min.js"></script>
+    <script src="/assets/js/sentry-init.js"></script>
     <script src="/invite.js"></script>
 </body>
 


### PR DESCRIPTION
## Summary
- Adiciona `sentry-init.js` em `invite.html` (única página que faltava)
- Atualiza Sentry browser SDK de v7.60.0 para v7.120.0 (match com backend)
- Adiciona 3 variáveis faltantes no `.env.example` para setup de alerts

## Context
Auditoria da integração GlitchTip + GitHub Issues encontrou 3 problemas menores.

## Test plan
- [ ] Abrir `/invite?token=test` e verificar no DevTools que `sentry-init.js` carrega
- [ ] Verificar que a versão do SDK no CDN é 7.120.0
- [ ] Verificar que `.env.example` tem as 3 novas variáveis

🤖 Generated with [Claude Code](https://claude.com/claude-code)