### PR TITLE
fix: padroniza modais e remove fullscreen mobile

### DIFF
--- a/public/group-details.html
+++ b/public/group-details.html
@@ -544,7 +544,7 @@
                                 </div>
                             </div>
                             <div class="modal fade" id="expenseModal" tabindex="-1" aria-labelledby="expenseModalLabel" aria-hidden="true">
-                                <div class="modal-dialog modal-xl modal-dialog-scrollable modal-fullscreen-sm-down">
+                                <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable modal-xl">
                                     <div class="modal-content">
                                         <div class="modal-header">
                                             <h5 class="modal-title" id="expenseModalLabel">Add expense</h5>
@@ -676,7 +676,7 @@
                                 </div>
                             </div>
                             <div class="modal fade" id="flightModal" tabindex="-1" aria-labelledby="flightModalLabel" aria-hidden="true">
-                                <div class="modal-dialog modal-xl modal-dialog-scrollable modal-fullscreen-sm-down">
+                                <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable modal-xl">
                                     <div class="modal-content">
                                         <div class="modal-header">
                                             <h5 class="modal-title" id="flightModalLabel">Add flight</h5>
@@ -900,7 +900,7 @@
                                 </div>
                             </div>
                             <div class="modal fade" id="lodgingModal" tabindex="-1" aria-labelledby="lodgingModalLabel" aria-hidden="true">
-                                <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable modal-xl modal-fullscreen-sm-down" role="document">
+                                <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable modal-xl" role="document">
                                     <div class="modal-content">
                                         <div class="modal-header">
                                             <h5 class="modal-title" id="lodgingModalLabel">Add lodging</h5>
@@ -1079,7 +1079,7 @@
                                 </div>
                             </div>
                             <div class="modal fade" id="lodgingDetailsModal" tabindex="-1" aria-labelledby="lodgingDetailsModalLabel" aria-hidden="true">
-                                <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable modal-fullscreen-sm-down" role="document">
+                                <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable modal-xl" role="document">
                                     <div class="modal-content">
                                         <div class="modal-header">
                                             <h5 class="modal-title" id="lodgingDetailsModalLabel">Lodging Details</h5>
@@ -1156,7 +1156,7 @@
                                 </div>
                             </div>
                             <div class="modal fade" id="transportModal" tabindex="-1" aria-labelledby="transportModalLabel" aria-hidden="true">
-                                <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable modal-xl modal-fullscreen-sm-down" role="document">
+                                <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable modal-xl" role="document">
                                     <div class="modal-content">
                                         <div class="modal-header">
                                             <h5 class="modal-title" id="transportModalLabel">Add transport</h5>
@@ -1317,7 +1317,7 @@
                                 </div>
                             </div>
                             <div class="modal fade" id="ticketModal" tabindex="-1" aria-labelledby="ticketModalLabel" aria-hidden="true">
-                                <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable modal-xl modal-fullscreen-sm-down" role="document">
+                                <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable modal-xl" role="document">
                                     <div class="modal-content">
                                         <div class="modal-header">
                                             <h5 class="modal-title" id="ticketModalLabel">Add ticket</h5>
@@ -1485,7 +1485,7 @@
     <div class="rightbar-overlay"></div>
 
     <div class="modal fade" id="avatarModal" tabindex="-1" aria-hidden="true">
-        <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title">Update photo</h5>
@@ -1511,7 +1511,7 @@
     </div>
 
     <div class="modal fade" id="confirmDeleteModal" tabindex="-1" aria-labelledby="confirmDeleteModalLabel" aria-hidden="true">
-        <div class="modal-dialog modal-dialog-centered modal-sm">
+        <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable modal-sm">
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title" id="confirmDeleteModalLabel">Confirm</h5>

--- a/public/group.html
+++ b/public/group.html
@@ -317,7 +317,7 @@
     <div class="rightbar-overlay"></div>
 
     <div class="modal fade" id="avatarModal" tabindex="-1" aria-hidden="true">
-        <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title">Update photo</h5>
@@ -343,7 +343,7 @@
     </div>
 
     <div class="modal fade" id="confirmDeleteModal" tabindex="-1" aria-labelledby="confirmDeleteModalLabel" aria-hidden="true">
-        <div class="modal-dialog modal-dialog-centered modal-sm">
+        <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable modal-sm">
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title" id="confirmDeleteModalLabel">Confirm</h5>

--- a/public/groups.html
+++ b/public/groups.html
@@ -289,7 +289,7 @@
     </div>
 
     <div class="modal fade" id="avatarModal" tabindex="-1" aria-hidden="true">
-        <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title">Update photo</h5>


### PR DESCRIPTION
## Summary
- Remove `modal-fullscreen-sm-down` dos 6 modais de formulário que causavam tela cheia no mobile
- Adiciona `modal-dialog-centered` nos modais expense e flight (consistência)
- Adiciona `modal-xl` no lodgingDetailsModal (consistência com o modal de edição)
- Adiciona `modal-dialog-scrollable` nos 3 avatarModal e 2 confirmDeleteModal

## Test plan
- [ ] Abrir cada modal no desktop e verificar que aparece centralizado com scroll interno
- [ ] Abrir cada modal no mobile (< 576px) e verificar que NÃO abre em tela cheia
- [ ] Testar scroll em modais com conteúdo longo (expense, flight, lodging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)