### PR TITLE
fix: corrige verificação de role do owner ao sair do grupo (#26)

### DIFF
--- a/server.js
+++ b/server.js
@@ -2285,7 +2285,7 @@ app.delete(
     requireCsrfToken,
     requireGroupMember,
     (req, res) => {
-        if (req.groupRole === 'owner') {
+        if (req.groupMember.role === 'owner') {
             return res.status(400).json({ error: 'Owner cannot leave the group. Transfer ownership or delete the group.' });
         }
         deleteGroupMember.run(req.groupId, req.user.sub);


### PR DESCRIPTION
## Summary
- Corrige bug onde `req.groupRole` era usado mas nunca atribuído (sempre `undefined`), permitindo que owners saíssem do grupo e criando grupos órfãos
- Alterado para `req.groupMember.role`, consistente com o padrão usado em `requireGroupRole`

Closes #26

## Test plan
- [x] Verificar que owner não consegue sair do próprio grupo (retorna erro 400)
- [x] Verificar que membros não-owner continuam conseguindo sair normalmente
- [x] Testes existentes passam sem regressão

🤖 Generated with [Claude Code](https://claude.com/claude-code)